### PR TITLE
Update link to dart-best-practices in SKILL.md to be a url instead of…

### DIFF
--- a/.agent/skills/dart-best-practices/SKILL.md
+++ b/.agent/skills/dart-best-practices/SKILL.md
@@ -47,6 +47,8 @@ or identifiers that cannot be broken.
 
 ## Related Skills
 
-- **[`dart-modern-features`](../dart-modern-features/SKILL.md)**: For idiomatic
+- **[dart-modern-features]**: For idiomatic
   usage of modern Dart features like Pattern Matching (useful for deep JSON
   extraction), Records, and Switch Expressions.
+
+[dart-modern-features]: https://github.com/kevmoo/dash_skills/blob/main/.agent/skills/dart-modern-features/SKILL.md

--- a/.agent/skills/dart-checks-migration/SKILL.md
+++ b/.agent/skills/dart-checks-migration/SKILL.md
@@ -127,8 +127,11 @@ check(it)..isGreaterThan(10)..isLessThan(20);
 
 ## Related Skills
 
-- **[`dart-test-fundamentals`](../dart-test-fundamentals/SKILL.md)**: Core
+- **[dart-test-fundamentals]**: Core
   concepts for structuring tests, lifecycles, and configuration.
-- **[`dart-matcher-best-practices`](../dart-matcher-best-practices/SKILL.md)**:
+- **[dart-matcher-best-practices]**:
   Best practices for the traditional `package:matcher` that is being migrated
   away from.
+
+[dart-test-fundamentals]: https://github.com/kevmoo/dash_skills/blob/main/.agent/skills/dart-test-fundamentals/SKILL.md
+[dart-matcher-best-practices]: https://github.com/kevmoo/dash_skills/blob/main/.agent/skills/dart-matcher-best-practices/SKILL.md

--- a/.agent/skills/dart-matcher-best-practices/SKILL.md
+++ b/.agent/skills/dart-matcher-best-practices/SKILL.md
@@ -106,8 +106,11 @@ expect(sideEffectState, equals('done')); // Race condition!
 
 ## Related Skills
 
-- **[`dart-test-fundamentals`](../dart-test-fundamentals/SKILL.md)**: Core
+- **[dart-test-fundamentals]**: Core
   concepts for structuring tests, lifecycles, and configuration.
-- **[`dart-checks-migration`](../dart-checks-migration/SKILL.md)**: Use this
+- **[dart-checks-migration]**: Use this
   skill if you are migrating tests from `package:matcher` to modern
   `package:checks`.
+
+[dart-test-fundamentals]: https://github.com/kevmoo/dash_skills/blob/main/.agent/skills/dart-test-fundamentals/SKILL.md
+[dart-checks-migration]: https://github.com/kevmoo/dash_skills/blob/main/.agent/skills/dart-checks-migration/SKILL.md

--- a/.agent/skills/dart-modern-features/SKILL.md
+++ b/.agent/skills/dart-modern-features/SKILL.md
@@ -239,3 +239,5 @@ LogLevel currentLevel = .info;
 - **[`dart-best-practices`][dart-best-practices]**: General code
   style and foundational Dart idioms that predate or complement the modern
   syntax features.
+
+[dart-best-practices]: https://github.com/kevmoo/dash_skills/blob/main/.agent/skills/dart-best-practices/SKILL.md

--- a/.agent/skills/dart-modern-features/SKILL.md
+++ b/.agent/skills/dart-modern-features/SKILL.md
@@ -236,7 +236,7 @@ LogLevel currentLevel = .info;
 
 ## Related Skills
 
-- **[`dart-best-practices`][dart-best-practices]**: General code
+- **[dart-best-practices]**: General code
   style and foundational Dart idioms that predate or complement the modern
   syntax features.
 

--- a/.agent/skills/dart-modern-features/SKILL.md
+++ b/.agent/skills/dart-modern-features/SKILL.md
@@ -236,6 +236,6 @@ LogLevel currentLevel = .info;
 
 ## Related Skills
 
-- **[`dart-best-practices`](https://github.com/kevmoo/dash_skills/blob/main/.agent/skills/dart-modern-features/SKILL.md)**: General code
+- **[`dart-best-practices`][dart-best-practices]**: General code
   style and foundational Dart idioms that predate or complement the modern
   syntax features.

--- a/.agent/skills/dart-modern-features/SKILL.md
+++ b/.agent/skills/dart-modern-features/SKILL.md
@@ -236,6 +236,6 @@ LogLevel currentLevel = .info;
 
 ## Related Skills
 
-- **[`dart-best-practices`](../dart-best-practices/SKILL.md)**: General code
+- **[`dart-best-practices`](https://github.com/kevmoo/dash_skills/blob/main/.agent/skills/dart-modern-features/SKILL.md)**: General code
   style and foundational Dart idioms that predate or complement the modern
   syntax features.

--- a/.agent/skills/dart-test-fundamentals/SKILL.md
+++ b/.agent/skills/dart-test-fundamentals/SKILL.md
@@ -117,8 +117,11 @@ timeouts:
 `dart-test-fundamentals` is the core skill for structuring and configuring
 tests. For writing assertions within those tests, refer to:
 
-- **[`dart-matcher-best-practices`](../dart-matcher-best-practices/SKILL.md)**:
+- **[dart-matcher-best-practices]**:
   Use this if the project sticks with the traditional
   `package:matcher` (`expect` calls).
-- **[`dart-checks-migration`](../dart-checks-migration/SKILL.md)**: Use this
+- **[dart-checks-migration]**: Use this
   if the project is migrating to the modern `package:checks` (`check` calls).
+
+[dart-matcher-best-practices]: https://github.com/kevmoo/dash_skills/blob/main/.agent/skills/dart-matcher-best-practices/SKILL.md
+[dart-checks-migration]: https://github.com/kevmoo/dash_skills/blob/main/.agent/skills/dart-checks-migration/SKILL.md


### PR DESCRIPTION
… a relative path. 

Fixes https://github.com/kevmoo/dart-best-practices/issues/2

Helps with portability both for users that do not have all your skills installed and when the skills are installed per project vs globally (or across different tools like claude and gemini cli) 