### PR TITLE
Update dart_skills_lint dependency to e449787 and centralize test configuration

### DIFF
--- a/tool/dart_skills_lint.yaml
+++ b/tool/dart_skills_lint.yaml
@@ -1,0 +1,7 @@
+dart_skills_lint:
+  rules:
+    check-relative-paths: error
+    check-absolute-paths: error
+    check-trailing-whitespace: error
+  directories:
+    - path: "../.agent/skills"

--- a/tool/pubspec.yaml
+++ b/tool/pubspec.yaml
@@ -16,3 +16,4 @@ dev_dependencies:
     git:
       url: https://github.com/flutter/skills
       path: tool/dart_skills_lint
+      ref: e4497873950727ee781fa411c1a2f624b1ec50c6

--- a/tool/test/validate_skills_test.dart
+++ b/tool/test/validate_skills_test.dart
@@ -3,6 +3,8 @@ import 'package:dart_skills_lint/dart_skills_lint.dart';
 import 'package:logging/logging.dart';
 import 'package:test/test.dart';
 
+const String _configFilePath = 'dart_skills_lint.yaml';
+
 void main() {
   test('Validate skills', () async {
     Logger.root.level = Level.ALL;
@@ -11,13 +13,11 @@ void main() {
     });
 
     try {
+      final Configuration config = await ConfigParser.loadConfig(
+        path: _configFilePath,
+      );
       final isValid = await validateSkills(
-        skillDirPaths: ['../.agent/skills'],
-        resolvedRules: {
-          'check-relative-paths': AnalysisSeverity.error,
-          'check-absolute-paths': AnalysisSeverity.error,
-          'check-trailing-whitespace': AnalysisSeverity.error,
-        },
+        config: config,
       );
       expect(
         isValid,


### PR DESCRIPTION
This pull request pins the `dart_skills_lint` Git reference in `tool/pubspec.yaml` to commit hash `e4497873950727ee781fa411c1a2f624b1ec50c6` (version `0.3.0`).
It introduces a centralized `tool/dart_skills_lint.yaml` configuration file and refactors `tool/test/validate_skills_test.dart` to load and enforce these shared validation rules dynamically.
## Pre-launch Checklist
- [x] Unit tests pass successfully.
- [x] Code is formatted cleanly and static analysis reports zero issues.