### PR TITLE
Add Claude Code plugin marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,13 @@
+{
+  "name": "kevmoo",
+  "owner": { "name": "kevmoo" },
+  "description": "Personal Dart & Flutter skills created by kevmoo.",
+  "plugins": [
+    {
+      "name": "dash-skills",
+      "source": "./plugins/dash-skills",
+      "description": "Dart & Flutter authoring, testing, and maintenance skills.",
+      "category": "development"
+    }
+  ]
+}

--- a/.github/workflows/validate_skills.yaml
+++ b/.github/workflows/validate_skills.yaml
@@ -4,13 +4,17 @@ on:
   pull_request:
     paths:
       - '.agent/skills/**'
-      - 'tool/skill_validator/**'
+      - 'tool/**'
+      - '.claude-plugin/**'
+      - 'plugins/**'
       - '.github/workflows/validate_skills.yaml'
   push:
     branches: [ main ]
     paths:
       - '.agent/skills/**'
-      - 'tool/skill_validator/**'
+      - 'tool/**'
+      - '.claude-plugin/**'
+      - 'plugins/**'
       - '.github/workflows/validate_skills.yaml'
 
 jobs:
@@ -36,3 +40,21 @@ jobs:
 
       - run: dart test
         if: always() && steps.pub-get.outcome == 'success'
+
+  # Canonical schema validation of the plugin marketplace manifests. The
+  # `claude` CLI is offline (no API key, no network), so no secrets are needed.
+  validate_marketplace:
+    runs-on: ubuntu-latest
+    # Override the workflow-level working directory so the validator runs
+    # against the repository root, not tool/.
+    defaults:
+      run:
+        working-directory: .
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm install -g @anthropic-ai/claude-code
+      - run: claude plugin validate .
+      - run: claude plugin validate ./plugins/dash-skills

--- a/README.md
+++ b/README.md
@@ -52,7 +52,10 @@ complex specialized tasks with high reliability.
 
 ### Claude Code (plugin marketplace)
 
-This repo is also a [Claude Code plugin marketplace](https://code.claude.com/docs/en/plugin-marketplaces).
+This repo is also a [Claude Code plugin marketplace][marketplace].
+
+[marketplace]: https://code.claude.com/docs/en/plugin-marketplaces
+
 Add the marketplace and install the plugin to get every skill at once:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -50,8 +50,21 @@ complex specialized tasks with high reliability.
 
 ## 🚀 Usage
 
-To use these skills with an agent (like [AntiGravity](https://antigravity.google)
-or [Gemini CLI](https://github.com/google/gemini-cli)):
+### Claude Code (plugin marketplace)
+
+This repo is also a [Claude Code plugin marketplace](https://code.claude.com/docs/en/plugin-marketplaces).
+Add the marketplace and install the plugin to get every skill at once:
+
+```bash
+/plugin marketplace add kevmoo/dash_skills
+/plugin install dash-skills@kevmoo
+```
+
+### Other agents
+
+To use these skills with another agent (like
+[AntiGravity](https://antigravity.google) or
+[Gemini CLI](https://github.com/google/gemini-cli)):
 
 1.  **Ingest**: The agent reads the `.agent/skills` directory.
 2.  **Activate**: Each skill contains a `SKILL.md` defining when and how it should be used.

--- a/plugins/dash-skills/.claude-plugin/plugin.json
+++ b/plugins/dash-skills/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "dash-skills",
+  "description": "Dart & Flutter authoring, testing, and maintenance skills.",
+  "author": { "name": "kevmoo" },
+  "homepage": "https://github.com/kevmoo/dash_skills",
+  "repository": "https://github.com/kevmoo/dash_skills",
+  "license": "Apache-2.0",
+  "keywords": ["dart", "flutter", "skills"]
+}

--- a/plugins/dash-skills/skills
+++ b/plugins/dash-skills/skills
@@ -1,0 +1,1 @@
+../../.agent/skills

--- a/tool/test/marketplace_plugin_test.dart
+++ b/tool/test/marketplace_plugin_test.dart
@@ -1,0 +1,105 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+const _marketplaceName = 'kevmoo';
+const _pluginName = 'dash-skills';
+
+Map<String, dynamic> _readJson(File file) {
+  expect(file.existsSync(), isTrue, reason: '${file.path} should exist');
+  return jsonDecode(file.readAsStringSync()) as Map<String, dynamic>;
+}
+
+void main() {
+  // CI runs `dart test` from the `tool/` package directory, so the repo root is
+  // exactly one parent up. No need to walk the tree hunting for a marker.
+  final repoRoot = Directory.current.parent;
+  final marketplaceFile = File(
+    p.join(repoRoot.path, '.claude-plugin', 'marketplace.json'),
+  );
+  final pluginLink = p.join(repoRoot.path, 'plugins', _pluginName, 'skills');
+  // Skills live under `.agent/skills/`, not a top-level `skills/`.
+  final canonicalSkills = Directory(p.join(repoRoot.path, '.agent', 'skills'));
+
+  group('Claude plugin marketplace', () {
+    test('marketplace.json declares the plugin', () {
+      final marketplace = _readJson(marketplaceFile);
+
+      expect(marketplace['name'], _marketplaceName);
+      expect(marketplace['owner'], isA<Map<String, dynamic>>());
+
+      final plugins = marketplace['plugins'] as List<dynamic>;
+      expect(plugins, hasLength(1));
+
+      final plugin = plugins.single as Map<String, dynamic>;
+      expect(plugin['name'], _pluginName);
+
+      // Guards against regressing to `source: "./"`, which would copy the
+      // entire repo into every user's cache.
+      expect(plugin['source'], './plugins/$_pluginName');
+    });
+
+    test('plugin source resolves to a directory with a plugin manifest', () {
+      final marketplace = _readJson(marketplaceFile);
+      final plugin = (marketplace['plugins'] as List<dynamic>).single
+          as Map<String, dynamic>;
+      final source = plugin['source'] as String;
+
+      expect(source, startsWith('./'));
+      expect(source, isNot(contains('..')));
+
+      final pluginDir = Directory(p.join(repoRoot.path, source));
+      expect(pluginDir.existsSync(), isTrue, reason: 'source "$source" exists');
+
+      final manifest = _readJson(
+        File(p.join(pluginDir.path, '.claude-plugin', 'plugin.json')),
+      );
+      expect(manifest['name'], plugin['name']);
+    });
+
+    test('skills symlink resolves to the .agent/skills directory', () {
+      expect(
+        FileSystemEntity.isLinkSync(pluginLink),
+        isTrue,
+        reason:
+            '"$pluginLink" must be a symlink. On Windows, ensure git checks '
+            'out symlinks (core.symlinks=true / Developer Mode).',
+      );
+
+      final resolvedLink = Link(pluginLink).resolveSymbolicLinksSync();
+      final expected = canonicalSkills.resolveSymbolicLinksSync();
+
+      expect(
+        p.equals(resolvedLink, expected),
+        isTrue,
+        reason: 'symlink should resolve to "$expected", got "$resolvedLink"',
+      );
+    });
+
+    test('every skill is reachable through the plugin symlink', () {
+      final skillNames = canonicalSkills
+          .listSync()
+          .whereType<Directory>()
+          .map((entity) => p.basename(entity.path))
+          .where(
+            (name) => File(
+              p.join(canonicalSkills.path, name, 'SKILL.md'),
+            ).existsSync(),
+          )
+          .toList();
+
+      expect(skillNames, isNotEmpty, reason: 'expected at least one skill');
+
+      for (final name in skillNames) {
+        final viaLink = File(p.join(pluginLink, name, 'SKILL.md'));
+        expect(
+          viaLink.existsSync(),
+          isTrue,
+          reason: 'skill "$name" should be reachable via the plugin symlink',
+        );
+      }
+    });
+  });
+}


### PR DESCRIPTION
Turns the repo into a [Claude Code plugin marketplace](https://code.claude.com/docs/en/plugin-marketplaces) (`kevmoo`) hosting one plugin (`dash-skills`) that exposes every skill in `.agent/skills/`.

The reason for this slightly complicated structure is to only ship the skills to users and not everything in the repo. 

## Install

```bash
/plugin marketplace add kevmoo/dash_skills
/plugin install dash-skills@kevmoo
```

## What's here

- **`.claude-plugin/marketplace.json`** — catalog with a relative `source` (`./plugins/dash-skills`) and no `version`, so the git commit SHA drives updates (users always get latest).
- **`plugins/dash-skills/.claude-plugin/plugin.json`** — plugin manifest (author `kevmoo`, Apache-2.0).
- **`plugins/dash-skills/skills` → `../../.agent/skills`** — a git symlink (mode `120000`). Keeping the plugin root tiny means only the skills get dereferenced and copied into user caches, not the whole repo.
- **`tool/test/marketplace_plugin_test.dart`** — structural wiring test folded into the existing `tool/` package (reuses its `path` + `test` deps): asserts the catalog declares the plugin, `source` resolves to a manifest, the symlink points at `.agent/skills`, and every skill is reachable through it.
- **`.github/workflows/validate_skills.yaml`** — added a `validate_marketplace` job running `claude plugin validate` (offline, no secrets), and broadened the trigger paths (see note below).
- **`README.md`** — documents the plugin install.

## Note: `validate_skills.yaml` trigger-path change

The trigger paths previously listed `tool/skill_validator/**`. That path is **dead** — the test package was flattened out of `tool/skill_validator/` up into `tool/` back in #20 (`d51deee`), which deleted `tool/skill_validator/{.gitignore,README.md,pubspec.yaml,test/...}`. Since then the filter matched zero files, so edits to the actual test package never triggered this workflow.

This PR replaces it with `tool/**` (where the package now lives) and adds `.claude-plugin/**` and `plugins/**`, so changes to the test package — including the new marketplace test — and to the marketplace manifests both trigger the workflow.

## Verification

- `claude plugin validate .` and `claude plugin validate ./plugins/dash-skills` pass (only the expected non-fatal "no version" warning).
- Full `dart test` (7 tests) and `dart analyze --fatal-infos` green; README validator passes.
- End-to-end install via the branch ref confirmed only the 11 skills land in the plugin cache (no repo tooling), with the symlink correctly dereferenced.