### PR TITLE
chore: configure native Dart workspace at root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .dart_tool/
+.packages
+build/
 pubspec.lock

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,10 @@
+name: dash_skills
+publish_to: none
+
+environment:
+  sdk: ^3.9.0
+
+workspace:
+  - tool
+  - skills/dart-test-coverage/example
+  - skills/dart-test-coverage/scripts

--- a/skills/dart-test-coverage/example/pubspec.yaml
+++ b/skills/dart-test-coverage/example/pubspec.yaml
@@ -3,6 +3,7 @@ publish_to: none
 
 environment:
   sdk: ^3.9.0
+resolution: workspace
 
 dev_dependencies:
   test: ^1.24.0

--- a/skills/dart-test-coverage/scripts/.gitignore
+++ b/skills/dart-test-coverage/scripts/.gitignore
@@ -1,2 +1,0 @@
-.dart_tool/
-pubspec.lock

--- a/skills/dart-test-coverage/scripts/pubspec.yaml
+++ b/skills/dart-test-coverage/scripts/pubspec.yaml
@@ -1,6 +1,7 @@
 name: interpret_coverage
 environment:
   sdk: '^3.9.0'
+resolution: workspace
 
 dev_dependencies:
   test: ^1.24.0

--- a/tool/.gitignore
+++ b/tool/.gitignore
@@ -1,8 +1,0 @@
-# https://dart.dev/guides/libraries/private-files
-
-# Files and directories created by pub
-.dart_tool/
-.packages
-.pub/
-build/
-pubspec.lock

--- a/tool/bin/readme.dart
+++ b/tool/bin/readme.dart
@@ -6,13 +6,17 @@ import 'package:yaml/yaml.dart';
 
 void main(List<String> arguments) async {
   final parser = ArgParser()
-    ..addFlag('write',
-        abbr: 'w',
-        negatable: false,
-        help: 'Writes the updated skills table to README.md.')
-    ..addFlag('validate',
-        negatable: false,
-        help: 'Validates that README.md is up-to-date with the latest skills.');
+    ..addFlag(
+      'write',
+      abbr: 'w',
+      negatable: false,
+      help: 'Writes the updated skills table to README.md.',
+    )
+    ..addFlag(
+      'validate',
+      negatable: false,
+      help: 'Validates that README.md is up-to-date with the latest skills.',
+    );
 
   final results = parser.parse(arguments);
   final writeMode = results['write'] as bool;
@@ -39,12 +43,13 @@ void main(List<String> arguments) async {
     exit(1);
   }
 
-  final skillDirs = skillsDir
-      .listSync()
-      .whereType<Directory>()
-      .where((dir) => File(p.join(dir.path, 'SKILL.md')).existsSync())
-      .toList()
-    ..sort((a, b) => p.basename(a.path).compareTo(p.basename(b.path)));
+  final skillDirs =
+      skillsDir
+          .listSync()
+          .whereType<Directory>()
+          .where((dir) => File(p.join(dir.path, 'SKILL.md')).existsSync())
+          .toList()
+        ..sort((a, b) => p.basename(a.path).compareTo(p.basename(b.path)));
 
   final listBuffer = StringBuffer();
   listBuffer.writeln('<!-- SKILLS_LIST_START -->');
@@ -63,15 +68,17 @@ void main(List<String> arguments) async {
       continue;
     }
 
-    final cleanDescription = LineSplitter.split(description.trim())
-        .map((line) => line.trim())
-        .join(' ');
+    final cleanDescription = LineSplitter.split(
+      description.trim(),
+    ).map((line) => line.trim()).join(' ');
 
     listBuffer.writeln(
-        '*   **[$title](skills/$skillName/SKILL.md)** — $cleanDescription');
+      '*   **[$title](skills/$skillName/SKILL.md)** — $cleanDescription',
+    );
     listBuffer.writeln('    ```bash');
-    listBuffer
-        .writeln('    npx skills add kevmoo/dash_skills --skill $skillName');
+    listBuffer.writeln(
+      '    npx skills add kevmoo/dash_skills --skill $skillName',
+    );
     listBuffer.writeln('    ```');
   }
   listBuffer.write('<!-- SKILLS_LIST_END -->');
@@ -87,7 +94,8 @@ void main(List<String> arguments) async {
 
   if (startIndex == -1 || endIndex == -1) {
     print(
-        'Error: Could not find comments <!-- SKILLS_LIST_START --> and <!-- SKILLS_LIST_END --> in README.md');
+      'Error: Could not find comments <!-- SKILLS_LIST_START --> and <!-- SKILLS_LIST_END --> in README.md',
+    );
     exit(1);
   }
 
@@ -156,7 +164,9 @@ String _getSkillTitle(String content, String fallback) {
   // If no H1, capitalize fallback
   return fallback
       .split('-')
-      .map((word) =>
-          word.isEmpty ? '' : '${word[0].toUpperCase()}${word.substring(1)}')
+      .map(
+        (word) =>
+            word.isEmpty ? '' : '${word[0].toUpperCase()}${word.substring(1)}',
+      )
       .join(' ');
 }

--- a/tool/pubspec.yaml
+++ b/tool/pubspec.yaml
@@ -2,7 +2,8 @@ name: _dash_skill_tool
 description: Helper tools for managing and validating skills.
 version: 1.0.0
 environment:
-  sdk: '>=3.0.0 <4.0.0'
+  sdk: ^3.9.0
+resolution: workspace
 
 dependencies:
   yaml: ^3.1.0

--- a/tool/test/marketplace_plugin_test.dart
+++ b/tool/test/marketplace_plugin_test.dart
@@ -43,8 +43,9 @@ void main() {
 
     test('plugin source resolves to a directory with a plugin manifest', () {
       final marketplace = _readJson(marketplaceFile);
-      final plugin = (marketplace['plugins'] as List<dynamic>).single
-          as Map<String, dynamic>;
+      final plugin =
+          (marketplace['plugins'] as List<dynamic>).single
+              as Map<String, dynamic>;
       final source = plugin['source'] as String;
 
       expect(source, startsWith('./'));

--- a/tool/test/readme_test.dart
+++ b/tool/test/readme_test.dart
@@ -3,10 +3,7 @@ import 'package:test/test.dart';
 
 void main() {
   test('validate README.md is up-to-date with the latest skills', () {
-    final result = Process.runSync(
-      'dart',
-      ['bin/readme.dart', '--validate'],
-    );
+    final result = Process.runSync('dart', ['bin/readme.dart', '--validate']);
     expect(
       result.exitCode,
       0,

--- a/tool/test/validate_skills_test.dart
+++ b/tool/test/validate_skills_test.dart
@@ -18,9 +18,7 @@ void main() {
       final Configuration config = await ConfigParser.loadConfig(
         path: _configFilePath,
       );
-      final isValid = await validateSkills(
-        config: config,
-      );
+      final isValid = await validateSkills(config: config);
       expect(
         isValid,
         isTrue,
@@ -33,9 +31,13 @@ void main() {
 
   test('Run skill/scripts/test', () {
     final skillsDir = Directory(
-        Directory.current.path.endsWith('tool') ? '../skills' : 'skills');
-    expect(skillsDir.existsSync(), isTrue,
-        reason: 'Skills directory not found at ${skillsDir.path}');
+      Directory.current.path.endsWith('tool') ? '../skills' : 'skills',
+    );
+    expect(
+      skillsDir.existsSync(),
+      isTrue,
+      reason: 'Skills directory not found at ${skillsDir.path}',
+    );
 
     final skillDirs = skillsDir.listSync().whereType<Directory>();
     for (final dir in skillDirs) {
@@ -45,25 +47,26 @@ void main() {
         print('Running tests in ${scriptsDir.path}');
 
         // Run pub get only if dependencies are not resolved
-        final packageConfig =
-            File('${scriptsDir.path}/.dart_tool/package_config.json');
+        final packageConfig = File(
+          '${scriptsDir.path}/.dart_tool/package_config.json',
+        );
         if (!packageConfig.existsSync()) {
-          Process.runSync(
-            'dart',
-            ['pub', 'get'],
-            workingDirectory: scriptsDir.path,
-          );
+          Process.runSync('dart', [
+            'pub',
+            'get',
+          ], workingDirectory: scriptsDir.path);
         }
 
-        final result = Process.runSync(
-          'dart',
-          ['test'],
-          workingDirectory: scriptsDir.path,
-        );
+        final result = Process.runSync('dart', [
+          'test',
+        ], workingDirectory: scriptsDir.path);
         print(result.stdout);
         print(result.stderr);
-        expect(result.exitCode, 0,
-            reason: 'Tests failed in ${scriptsDir.path}');
+        expect(
+          result.exitCode,
+          0,
+          reason: 'Tests failed in ${scriptsDir.path}',
+        );
       }
     }
   });


### PR DESCRIPTION
Sets up a Native Dart Workspace at the repository root, adding resolution: workspace to member packages, and unifying the gitignore configs.