### PR TITLE
feat(skills): add profile-dart-code skill and VM service script

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ npx skills add kevmoo/dash_skills --skill <skill-name>
 | **[dart-package-maintenance](skills/dart-package-maintenance/SKILL.md)** | Guidelines for maintaining external Dart packages, covering versioning, publishing workflows, and pull request management. Use when updating Dart packages, preparing for a release, or managing collaborative changes in a repository. | Versioning & CHANGELOG sync, Publishing workflow guidelines, Pull request management |
 | **[dart-test-coverage](skills/dart-test-coverage/SKILL.md)** | Understand and improve test coverage in a Dart package. Helps agents run coverage, interpret results, and identify missed lines. | LCOV report collection, Missed line identification, Coverage analysis & improvement |
 | **[dart-test-fundamentals](skills/dart-test-fundamentals/SKILL.md)** | Core concepts and best practices for `package:test`. Covers `test`, `group`, lifecycle methods (`setUp`, `tearDown`), and configuration (`dart_test.yaml`). | Package test core concepts, Test lifecycle (setUp, tearDown), dart_test.yaml configuration |
+| **[profile-dart-code](skills/profile-dart-code/SKILL.md)** | Profile Dart command-line applications using the VM Service protocol to capture CPU samples and identify performance bottlenecks. Helps agents automate CPU profiling, generate function call breakdown summaries, and export JSON profiles without a browser or DevTools. | Automated VM Service WebSocket connection, CPU sampling and top-function call summary, JSON trace export for further analysis |
 <!-- SKILLS_LIST_END -->
 
 ## 🚀 Usage

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,3 +8,4 @@ workspace:
   - tool
   - skills/dart-test-coverage/example
   - skills/dart-test-coverage/scripts
+  - skills/profile-dart-code/scripts

--- a/skills/profile-dart-code/SKILL.md
+++ b/skills/profile-dart-code/SKILL.md
@@ -1,8 +1,10 @@
 ---
 name: profile-dart-code
 description: |-
-  Profile Dart command-line applications using the VM Service protocol to capture CPU samples and identify performance bottlenecks.
-  Helps agents automate CPU profiling, generate function call breakdown summaries, and export JSON profiles without a browser or DevTools.
+  Profile Dart command-line applications using the VM Service protocol to
+  capture CPU samples and identify performance bottlenecks. Helps agents
+  automate CPU profiling, generate function call breakdown summaries, and
+  export JSON profiles without a browser or DevTools.
 key_features:
   - Automated VM Service WebSocket connection
   - CPU sampling and top-function call summary
@@ -11,30 +13,50 @@ key_features:
 
 # Dart CPU Profiling
 
-Guidelines and automated tools for capturing CPU profiles and identifying bottlenecks in Dart command-line applications.
+Guidelines and automated tools for capturing CPU profiles and identifying
+bottlenecks in Dart command-line applications.
 
 ## When to use this skill
-- When asked to profile, optimize, or benchmark CPU execution of a Dart script or CLI tool.
-- When investigating hot loops, heavy function calls, or unexpected execution overhead.
+- When asked to profile, optimize, or benchmark CPU execution of a Dart script
+  or CLI tool.
+- When investigating hot loops, heavy function calls, or unexpected execution
+  overhead.
 
 ## Workflow
-1. **Ensure clean compilation**: Make sure the target Dart script runs cleanly (`dart run <script.dart>`).
-2. **Run Profiler Script**: Use the automated profiling helper script inside this skill directory to launch the target app with VM Service observability enabled, capture CPU samples, and output top-consuming functions.
-3. **Analyze & Optimize**: Review the self and total sample percentages reported by the tool to pinpoint bottlenecks (e.g., excessive object allocation, costly hashing, virtual dispatch overhead).
+1. **Ensure clean compilation**: Make sure the target Dart script runs cleanly
+   (`dart run <script.dart>`).
+2. **Run Profiler Script**: Use the automated profiling helper script inside
+   this skill directory to launch the target app with VM Service observability
+   enabled, capture CPU samples, and output top-consuming functions.
+3. **Analyze & Optimize**: Review the self and total sample percentages
+   reported by the tool to pinpoint bottlenecks (e.g., excessive object
+   allocation, costly hashing, virtual dispatch overhead).
 
 ## Running the Profiler Helper Script
 
-This repository includes a zero-dependency (using only official `vm_service`) profiling script that launches any Dart file, connects to the VM Service, waits for execution to complete (`--pause-isolates-on-exit`), retrieves CPU samples, and prints a clean summary while exporting the full JSON profile.
+This repository includes a zero-dependency (using only official `vm_service`)
+profiling script that launches any Dart file, connects to the VM Service, waits
+for execution to complete (`--pause-isolates-on-exit`), retrieves CPU samples,
+and prints a clean summary while exporting the full JSON profile.
 
 Run it from any working directory:
 ```bash
-dart run <dash_skills_repo>/skills/profile-dart-code/scripts/profile.dart --out=cpu_profile.json -- <path_to_target.dart> [target_arguments...]
+dart run <dash_skills_repo>/skills/profile-dart-code/scripts/bin/profile.dart --out=cpu_profile.json -- <path_to_target.dart> [target_arguments...]
 ```
 
 ### Script Arguments
-- `-o, --out=<file>`: Output file path to save the raw JSON CPU profile (default: `cpu_profile.json`).
-- `-p, --period=<micros>`: Sampling interval in microseconds (default: `1000`µs = 1ms). Minimum `50`µs.
-- `-- <target.dart> [args...]`: The Dart script to profile, followed by any arguments passed to `main()`.
+- `-o, --out=<file>`: Output file path to save the raw JSON CPU profile
+  (default: `cpu_profile.json`).
+- `-p, --period=<micros>`: Sampling interval in microseconds (default: `1000`µs
+  = 1ms). Minimum `50`µs.
+- `-- <target.dart> [args...]`: The Dart script to profile, followed by any
+  arguments passed to `main()`.
+
+> [!WARNING]
+> **Potential Hangs**: When profiling or debugging Dart targets using VM services,
+> target exceptions or connection issues can cause the process to hang
+> indefinitely. Ensure your target script handles timeouts, and monitor the
+> process output.
 
 ### Example Output
 ```
@@ -50,6 +72,11 @@ Saved complete JSON profile to: cpu_profile.json
 ```
 
 ## Best Practices for Interpreting Profiles
-1. **Focus on Self % vs. Total %**: High `self %` indicates where CPU time is spent directly inside a function's own body (math, loop branching, array indexing). High `total %` with low `self %` indicates a dispatcher or outer orchestration loop.
-2. **Look for Hidden Overhead**: Watch out for implicit object allocations (`_copyData`, iterator wrappers, closure creation) inside tight loops.
-3. **Verify Optimizations Empirically**: Always record baseline sample counts and execution duration (`time -v`) before and after applying optimizations.
+1. **Focus on Self % vs. Total %**: High `self %` indicates where CPU time is
+   spent directly inside a function's own body (math, loop branching, array
+   indexing). High `total %` with low `self %` indicates a dispatcher or outer
+   orchestration loop.
+2. **Look for Hidden Overhead**: Watch out for implicit object allocations
+   (`_copyData`, iterator wrappers, closure creation) inside tight loops.
+3. **Verify Optimizations Empirically**: Always record baseline sample counts
+   and execution duration (`time -v`) before and after applying optimizations.

--- a/skills/profile-dart-code/SKILL.md
+++ b/skills/profile-dart-code/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: profile-dart-code
+description: |-
+  Profile Dart command-line applications using the VM Service protocol to capture CPU samples and identify performance bottlenecks.
+  Helps agents automate CPU profiling, generate function call breakdown summaries, and export JSON profiles without a browser or DevTools.
+key_features:
+  - Automated VM Service WebSocket connection
+  - CPU sampling and top-function call summary
+  - JSON trace export for further analysis
+---
+
+# Dart CPU Profiling
+
+Guidelines and automated tools for capturing CPU profiles and identifying bottlenecks in Dart command-line applications.
+
+## When to use this skill
+- When asked to profile, optimize, or benchmark CPU execution of a Dart script or CLI tool.
+- When investigating hot loops, heavy function calls, or unexpected execution overhead.
+
+## Workflow
+1. **Ensure clean compilation**: Make sure the target Dart script runs cleanly (`dart run <script.dart>`).
+2. **Run Profiler Script**: Use the automated profiling helper script inside this skill directory to launch the target app with VM Service observability enabled, capture CPU samples, and output top-consuming functions.
+3. **Analyze & Optimize**: Review the self and total sample percentages reported by the tool to pinpoint bottlenecks (e.g., excessive object allocation, costly hashing, virtual dispatch overhead).
+
+## Running the Profiler Helper Script
+
+This repository includes a zero-dependency (using only official `vm_service`) profiling script that launches any Dart file, connects to the VM Service, waits for execution to complete (`--pause-isolates-on-exit`), retrieves CPU samples, and prints a clean summary while exporting the full JSON profile.
+
+Run it from any working directory:
+```bash
+dart run <dash_skills_repo>/skills/profile-dart-code/scripts/profile.dart --out=cpu_profile.json -- <path_to_target.dart> [target_arguments...]
+```
+
+### Script Arguments
+- `-o, --out=<file>`: Output file path to save the raw JSON CPU profile (default: `cpu_profile.json`).
+- `-p, --period=<micros>`: Sampling interval in microseconds (default: `1000`µs = 1ms). Minimum `50`µs.
+- `-- <target.dart> [args...]`: The Dart script to profile, followed by any arguments passed to `main()`.
+
+### Example Output
+```
+Connecting to VM service at ws://127.0.0.1:8181/ws...
+Target execution paused at exit. Retrieving CPU profile samples...
+
+=== Top CPU Functions (Self Samples) ===
+ 1. _PuzzleSmart._shiftSlice (self: 34.2%, total: 41.0%)
+ 2. _countInversions (self: 18.5%, total: 18.5%)
+ 3. shortestPaths (self: 12.1%, total: 98.4%)
+
+Saved complete JSON profile to: cpu_profile.json
+```
+
+## Best Practices for Interpreting Profiles
+1. **Focus on Self % vs. Total %**: High `self %` indicates where CPU time is spent directly inside a function's own body (math, loop branching, array indexing). High `total %` with low `self %` indicates a dispatcher or outer orchestration loop.
+2. **Look for Hidden Overhead**: Watch out for implicit object allocations (`_copyData`, iterator wrappers, closure creation) inside tight loops.
+3. **Verify Optimizations Empirically**: Always record baseline sample counts and execution duration (`time -v`) before and after applying optimizations.

--- a/skills/profile-dart-code/scripts/bin/profile.dart
+++ b/skills/profile-dart-code/scripts/bin/profile.dart
@@ -62,43 +62,41 @@ void main(List<String> arguments) async {
     r'|The Dart VM service is listening on ((http|ws)://[a-zA-Z0-9\.:]+[^\s]*)',
   );
 
-  process.stdout
-      .transform(utf8.decoder)
-      .transform(const LineSplitter())
-      .listen((line) {
-    final match = uriRegex.firstMatch(line);
-    if (match != null && !wsUriCompleter.isCompleted) {
-      final rawUrl = match.group(1) ?? match.group(3);
-      if (rawUrl != null) {
-        var wsUrl = rawUrl.replaceFirst('http://', 'ws://');
-        if (!wsUrl.endsWith('/ws')) {
-          wsUrl = wsUrl.endsWith('/') ? '${wsUrl}ws' : '$wsUrl/ws';
+  process.stdout.transform(utf8.decoder).transform(const LineSplitter()).listen(
+    (line) {
+      final match = uriRegex.firstMatch(line);
+      if (match != null && !wsUriCompleter.isCompleted) {
+        final rawUrl = match.group(1) ?? match.group(3);
+        if (rawUrl != null) {
+          var wsUrl = rawUrl.replaceFirst('http://', 'ws://');
+          if (!wsUrl.endsWith('/ws')) {
+            wsUrl = wsUrl.endsWith('/') ? '${wsUrl}ws' : '$wsUrl/ws';
+          }
+          wsUriCompleter.complete(Uri.parse(wsUrl));
         }
-        wsUriCompleter.complete(Uri.parse(wsUrl));
+      } else {
+        print(line);
       }
-    } else if (!wsUriCompleter.isCompleted) {
-      print(line);
-    }
-  });
+    },
+  );
 
-  process.stderr
-      .transform(utf8.decoder)
-      .transform(const LineSplitter())
-      .listen((line) {
-    final match = uriRegex.firstMatch(line);
-    if (match != null && !wsUriCompleter.isCompleted) {
-      final rawUrl = match.group(1) ?? match.group(3);
-      if (rawUrl != null) {
-        var wsUrl = rawUrl.replaceFirst('http://', 'ws://');
-        if (!wsUrl.endsWith('/ws')) {
-          wsUrl = wsUrl.endsWith('/') ? '${wsUrl}ws' : '$wsUrl/ws';
+  process.stderr.transform(utf8.decoder).transform(const LineSplitter()).listen(
+    (line) {
+      final match = uriRegex.firstMatch(line);
+      if (match != null && !wsUriCompleter.isCompleted) {
+        final rawUrl = match.group(1) ?? match.group(3);
+        if (rawUrl != null) {
+          var wsUrl = rawUrl.replaceFirst('http://', 'ws://');
+          if (!wsUrl.endsWith('/ws')) {
+            wsUrl = wsUrl.endsWith('/') ? '${wsUrl}ws' : '$wsUrl/ws';
+          }
+          wsUriCompleter.complete(Uri.parse(wsUrl));
         }
-        wsUriCompleter.complete(Uri.parse(wsUrl));
+      } else {
+        stderr.writeln(line);
       }
-    } else {
-      stderr.writeln(line);
-    }
-  });
+    },
+  );
 
   final wsUri = await wsUriCompleter.future.timeout(
     const Duration(seconds: 15),
@@ -123,26 +121,54 @@ void main(List<String> arguments) async {
   final isolateRef = isolates.first;
   final isolateId = isolateRef.id!;
 
-  // Wait until isolate hits kPauseExit
+  bool connectionLost = false;
+  service.onDone.then((_) {
+    connectionLost = true;
+  });
+
   var isPausedAtExit = false;
-  while (!isPausedAtExit) {
-    final isolate = await service.getIsolate(isolateId);
-    if (isolate.pauseEvent?.kind == EventKind.kPauseExit) {
-      isPausedAtExit = true;
+  while (!isPausedAtExit && !connectionLost) {
+    try {
+      final isolate = await service.getIsolate(isolateId);
+      final pauseKind = isolate.pauseEvent?.kind;
+      if (pauseKind == EventKind.kPauseExit) {
+        isPausedAtExit = true;
+        break;
+      }
+      if (pauseKind == EventKind.kPauseException) {
+        print('Target isolate paused on exception!');
+        break;
+      }
+    } catch (e) {
+      print('Error querying VM service: $e');
       break;
     }
-    if (isolate.pauseEvent?.kind == EventKind.kResume &&
-        (await process.exitCode.timeout(const Duration(milliseconds: 50),
-                onTimeout: () => -1)) !=
-            -1) {
+
+    final exitCode = await process.exitCode.timeout(
+      const Duration(milliseconds: 50),
+      onTimeout: () => -1,
+    );
+    if (exitCode != -1) {
+      print('Target process exited with code $exitCode');
       break;
     }
     await Future.delayed(const Duration(milliseconds: 100));
   }
 
+  if (!isPausedAtExit) {
+    print(
+      'Error: Target process did not pause at exit. Cannot retrieve CPU profile.',
+    );
+    await service.dispose();
+    exit(1);
+  }
+
   print('Target execution finished. Retrieving CPU profile samples...');
-  final cpuSamples =
-      await service.getCpuSamples(isolateId, 0, 0x7fffffffffffffff);
+  final cpuSamples = await service.getCpuSamples(
+    isolateId,
+    0,
+    0x7fffffffffffffff,
+  );
 
   final sampleCount = cpuSamples.sampleCount ?? 0;
   print('Retrieved $sampleCount samples.');
@@ -154,9 +180,11 @@ void main(List<String> arguments) async {
 
   print('\n=== Top 15 Functions by Self CPU Samples ===');
   print(
-      '${'Self %'.padRight(8)} | ${'Self'.padRight(8)} | ${'Total %'.padRight(8)} | Function');
+    '${'Self %'.padRight(8)} | ${'Self'.padRight(8)} | ${'Total %'.padRight(8)} | Function',
+  );
   print(
-      '-----------------------------------------------------------------------');
+    '-----------------------------------------------------------------------',
+  );
 
   var displayed = 0;
   for (final func in sortedFunctions) {
@@ -168,13 +196,15 @@ void main(List<String> arguments) async {
     final totalPct = sampleCount > 0 ? (totalCount * 100.0 / sampleCount) : 0.0;
     final name = func.function?.name ?? func.resolvedUrl ?? 'Unknown';
     print(
-        '${pct.toStringAsFixed(1).padLeft(6)}% | ${count.toString().padLeft(8)} | ${totalPct.toStringAsFixed(1).padLeft(6)}% | $name');
+      '${pct.toStringAsFixed(1).padLeft(6)}% | ${count.toString().padLeft(8)} | ${totalPct.toStringAsFixed(1).padLeft(6)}% | $name',
+    );
     displayed++;
   }
 
   final outFile = File(outPath);
   await outFile.writeAsString(
-      const JsonEncoder.withIndent('  ').convert(cpuSamples.toJson()));
+    const JsonEncoder.withIndent('  ').convert(cpuSamples.toJson()),
+  );
   print('\nSaved complete JSON CPU profile to: $outPath');
 
   await service.resume(isolateId);

--- a/skills/profile-dart-code/scripts/profile.dart
+++ b/skills/profile-dart-code/scripts/profile.dart
@@ -1,0 +1,183 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:args/args.dart';
+import 'package:vm_service/vm_service.dart';
+import 'package:vm_service/vm_service_io.dart';
+
+void main(List<String> arguments) async {
+  final parser = ArgParser()
+    ..addOption(
+      'out',
+      abbr: 'o',
+      defaultsTo: 'cpu_profile.json',
+      help: 'Path to save the JSON CPU profile output.',
+    )
+    ..addOption(
+      'period',
+      abbr: 'p',
+      defaultsTo: '1000',
+      help: 'Sampling period in microseconds (minimum 50).',
+    )
+    ..addFlag(
+      'help',
+      abbr: 'h',
+      negatable: false,
+      help: 'Print usage instructions.',
+    );
+
+  final results = parser.parse(arguments);
+  if (results['help'] as bool || results.rest.isEmpty) {
+    print('Usage: dart profile.dart [options] -- <target.dart> [args...]');
+    print(parser.usage);
+    exit(results['help'] as bool ? 0 : 64);
+  }
+
+  final outPath = results['out'] as String;
+  final period = int.tryParse(results['period'] as String) ?? 1000;
+  final targetScript = results.rest.first;
+  final targetArgs = results.rest.sublist(1);
+
+  if (!File(targetScript).existsSync()) {
+    print('Error: Target script not found at $targetScript');
+    exit(66);
+  }
+
+  print('Launching target: $targetScript ${targetArgs.join(' ')}');
+
+  final vmArgs = [
+    '--observe=0',
+    '--pause-isolates-on-exit',
+    '--profile-period=$period',
+    targetScript,
+    ...targetArgs,
+  ];
+
+  final process = await Process.start(Platform.resolvedExecutable, vmArgs);
+
+  final wsUriCompleter = Completer<Uri>();
+  final uriRegex = RegExp(
+    r'Observatory listening on ((http|ws)://[a-zA-Z0-9\.:]+[^\s]*)'
+    r'|The Dart VM service is listening on ((http|ws)://[a-zA-Z0-9\.:]+[^\s]*)',
+  );
+
+  process.stdout
+      .transform(utf8.decoder)
+      .transform(const LineSplitter())
+      .listen((line) {
+    final match = uriRegex.firstMatch(line);
+    if (match != null && !wsUriCompleter.isCompleted) {
+      final rawUrl = match.group(1) ?? match.group(3);
+      if (rawUrl != null) {
+        var wsUrl = rawUrl.replaceFirst('http://', 'ws://');
+        if (!wsUrl.endsWith('/ws')) {
+          wsUrl = wsUrl.endsWith('/') ? '${wsUrl}ws' : '$wsUrl/ws';
+        }
+        wsUriCompleter.complete(Uri.parse(wsUrl));
+      }
+    } else if (!wsUriCompleter.isCompleted) {
+      print(line);
+    }
+  });
+
+  process.stderr
+      .transform(utf8.decoder)
+      .transform(const LineSplitter())
+      .listen((line) {
+    final match = uriRegex.firstMatch(line);
+    if (match != null && !wsUriCompleter.isCompleted) {
+      final rawUrl = match.group(1) ?? match.group(3);
+      if (rawUrl != null) {
+        var wsUrl = rawUrl.replaceFirst('http://', 'ws://');
+        if (!wsUrl.endsWith('/ws')) {
+          wsUrl = wsUrl.endsWith('/') ? '${wsUrl}ws' : '$wsUrl/ws';
+        }
+        wsUriCompleter.complete(Uri.parse(wsUrl));
+      }
+    } else {
+      stderr.writeln(line);
+    }
+  });
+
+  final wsUri = await wsUriCompleter.future.timeout(
+    const Duration(seconds: 15),
+    onTimeout: () {
+      print('Timeout waiting for VM service URI.');
+      process.kill();
+      exit(1);
+    },
+  );
+
+  print('Connecting to VM service at $wsUri...');
+  final service = await vmServiceConnectUri(wsUri.toString());
+
+  final vm = await service.getVM();
+  final isolates = vm.isolates ?? [];
+  if (isolates.isEmpty) {
+    print('Error: No isolates found.');
+    process.kill();
+    exit(1);
+  }
+
+  final isolateRef = isolates.first;
+  final isolateId = isolateRef.id!;
+
+  // Wait until isolate hits kPauseExit
+  var isPausedAtExit = false;
+  while (!isPausedAtExit) {
+    final isolate = await service.getIsolate(isolateId);
+    if (isolate.pauseEvent?.kind == EventKind.kPauseExit) {
+      isPausedAtExit = true;
+      break;
+    }
+    if (isolate.pauseEvent?.kind == EventKind.kResume &&
+        (await process.exitCode.timeout(const Duration(milliseconds: 50),
+                onTimeout: () => -1)) !=
+            -1) {
+      break;
+    }
+    await Future.delayed(const Duration(milliseconds: 100));
+  }
+
+  print('Target execution finished. Retrieving CPU profile samples...');
+  final cpuSamples =
+      await service.getCpuSamples(isolateId, 0, 0x7fffffffffffffff);
+
+  final sampleCount = cpuSamples.sampleCount ?? 0;
+  print('Retrieved $sampleCount samples.');
+
+  final functions = cpuSamples.functions ?? [];
+
+  final sortedFunctions = List<ProfileFunction>.from(functions)
+    ..sort((a, b) => (b.exclusiveTicks ?? 0).compareTo(a.exclusiveTicks ?? 0));
+
+  print('\n=== Top 15 Functions by Self CPU Samples ===');
+  print(
+      '${'Self %'.padRight(8)} | ${'Self'.padRight(8)} | ${'Total %'.padRight(8)} | Function');
+  print(
+      '-----------------------------------------------------------------------');
+
+  var displayed = 0;
+  for (final func in sortedFunctions) {
+    if (displayed >= 15) break;
+    final count = func.exclusiveTicks ?? 0;
+    if (count <= 0 && displayed > 0) break;
+    final pct = sampleCount > 0 ? (count * 100.0 / sampleCount) : 0.0;
+    final totalCount = func.inclusiveTicks ?? 0;
+    final totalPct = sampleCount > 0 ? (totalCount * 100.0 / sampleCount) : 0.0;
+    final name = func.function?.name ?? func.resolvedUrl ?? 'Unknown';
+    print(
+        '${pct.toStringAsFixed(1).padLeft(6)}% | ${count.toString().padLeft(8)} | ${totalPct.toStringAsFixed(1).padLeft(6)}% | $name');
+    displayed++;
+  }
+
+  final outFile = File(outPath);
+  await outFile.writeAsString(
+      const JsonEncoder.withIndent('  ').convert(cpuSamples.toJson()));
+  print('\nSaved complete JSON CPU profile to: $outPath');
+
+  await service.resume(isolateId);
+  await service.dispose();
+  await process.exitCode;
+}

--- a/skills/profile-dart-code/scripts/pubspec.yaml
+++ b/skills/profile-dart-code/scripts/pubspec.yaml
@@ -2,7 +2,8 @@ name: profile_dart_code_scripts
 description: Helper scripts for profiling Dart applications via the VM Service protocol.
 publish_to: none
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.9.0
+resolution: workspace
 dependencies:
   args: ^2.5.0
   path: ^1.9.0

--- a/skills/profile-dart-code/scripts/pubspec.yaml
+++ b/skills/profile-dart-code/scripts/pubspec.yaml
@@ -1,0 +1,13 @@
+name: profile_dart_code_scripts
+description: Helper scripts for profiling Dart applications via the VM Service protocol.
+publish_to: none
+environment:
+  sdk: ^3.0.0
+dependencies:
+  args: ^2.5.0
+  path: ^1.9.0
+  vm_service: ^15.0.0
+dev_dependencies:
+  lints: ^5.0.0
+  test: ^1.24.0
+  test_process: ^2.1.0

--- a/skills/profile-dart-code/scripts/test/profile_test.dart
+++ b/skills/profile-dart-code/scripts/test/profile_test.dart
@@ -1,0 +1,38 @@
+import 'dart:io';
+import 'package:test/test.dart';
+import 'package:test_process/test_process.dart';
+
+void main() {
+  test('profile script prints usage on --help', () async {
+    final process = await TestProcess.start(Platform.resolvedExecutable, [
+      'profile.dart',
+      '--help',
+    ]);
+    await process.shouldExit(0);
+  });
+
+  test('profile script profiles a simple dummy target', () async {
+    final tempDir = await Directory.systemTemp.createTemp('profile_test_');
+    final dummyScript = File('${tempDir.path}/dummy.dart');
+    await dummyScript.writeAsString('''
+void main() {
+  var sum = 0;
+  for (var i = 0; i < 5000000; i++) {
+    sum += i;
+  }
+}
+''');
+
+    final outJson = '${tempDir.path}/profile.json';
+    final process = await TestProcess.start(Platform.resolvedExecutable, [
+      'profile.dart',
+      '--out',
+      outJson,
+      '--',
+      dummyScript.path,
+    ]);
+    await process.shouldExit(0);
+    expect(File(outJson).existsSync(), isTrue);
+    await tempDir.delete(recursive: true);
+  }, timeout: const Timeout(Duration(minutes: 1)));
+}

--- a/skills/profile-dart-code/scripts/test/profile_test.dart
+++ b/skills/profile-dart-code/scripts/test/profile_test.dart
@@ -1,18 +1,52 @@
 import 'dart:io';
+import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 import 'package:test_process/test_process.dart';
 
+String _locateProfileScript() {
+  final candidate1 = p.join(Directory.current.path, 'profile.dart');
+  final candidate2 = p.join(Directory.current.path, 'bin', 'profile.dart');
+  final candidate3 = p.join(
+    Directory.current.path,
+    'skills',
+    'profile-dart-code',
+    'scripts',
+    'profile.dart',
+  );
+  final candidate4 = p.join(
+    Directory.current.path,
+    'skills',
+    'profile-dart-code',
+    'scripts',
+    'bin',
+    'profile.dart',
+  );
+
+  for (final candidate in [candidate1, candidate2, candidate3, candidate4]) {
+    if (File(candidate).existsSync()) {
+      return candidate;
+    }
+  }
+  throw StateError(
+    'Could not locate profile.dart. Current directory: ${Directory.current.path}',
+  );
+}
+
 void main() {
   test('profile script prints usage on --help', () async {
+    final scriptPath = _locateProfileScript();
     final process = await TestProcess.start(Platform.resolvedExecutable, [
-      'profile.dart',
+      scriptPath,
       '--help',
     ]);
     await process.shouldExit(0);
   });
 
   test('profile script profiles a simple dummy target', () async {
+    final scriptPath = _locateProfileScript();
     final tempDir = await Directory.systemTemp.createTemp('profile_test_');
+    addTearDown(() => tempDir.delete(recursive: true));
+
     final dummyScript = File('${tempDir.path}/dummy.dart');
     await dummyScript.writeAsString('''
 void main() {
@@ -25,7 +59,7 @@ void main() {
 
     final outJson = '${tempDir.path}/profile.json';
     final process = await TestProcess.start(Platform.resolvedExecutable, [
-      'profile.dart',
+      scriptPath,
       '--out',
       outJson,
       '--',
@@ -33,6 +67,5 @@ void main() {
     ]);
     await process.shouldExit(0);
     expect(File(outJson).existsSync(), isTrue);
-    await tempDir.delete(recursive: true);
   }, timeout: const Timeout(Duration(minutes: 1)));
 }


### PR DESCRIPTION
Add profile-dart-code skill to automate CPU sampling and bottleneck analysis for Dart CLI applications using the VM Service protocol.

* Add `SKILL.md` documentation covering setup, argument usage, and best practices for interpreting `exclusiveTicks` vs `inclusiveTicks`.
* Add standalone `profile.dart` helper script that launches target scripts with `--observe --pause-isolates-on-exit`, connects to VM Service WebSocket, and outputs top CPU function breakdown alongside `cpu_profile.json`.
* Add unit tests in `profile_test.dart` and update repo `README.md` skills table.
